### PR TITLE
Include email in ID Token

### DIFF
--- a/gz-token.html
+++ b/gz-token.html
@@ -174,7 +174,7 @@
         if (!url.endsWith('/'))
           url += '/'
         url += 'token'
-        this.$.ajax.url = url + '?username=' + this.username
+        this.$.ajax.url = url
 
         this.$.ajax.headers.authorization = 'Bearer ' + this.auth0_token
         this.$.ajax.withCredentials = true

--- a/gz-token.html
+++ b/gz-token.html
@@ -214,7 +214,13 @@
         localStorage.setItem('gztoken_auth0_id', this.auth0_id);
         localStorage.setItem('gztoken_auth0_domain', this.auth0_domain);
 
-        this.lock = new Auth0Lock(this.auth0_id, this.auth0_domain);
+        this.lock = new Auth0Lock(this.auth0_id, this.auth0_domain, {
+           auth: {
+            params: {
+              scope: 'openid email'
+            }
+          }
+        })
 
         // This is called after page refresh due to redirect
         const that = this;


### PR DESCRIPTION
This PR is one of the parts to address [CLOUD-183](https://osrfoundation.atlassian.net/browse/CLOUD-183). The other PR is [here](https://bitbucket.org/osrf/cloudsim-auth/pull-requests/26/obtain-username-from-token/diff).

This allows the obtained Auth0 JWT to include the email in it's payload. In the Cloudsim Auth server, we will use this email as the username, instead of passing it as a query. The following example payloads were obtained with a local Cloudsim Auth server:

Before changes:
```
{
  "iss": "https://germanmas.auth0.com/",
  "sub": "google-oauth2|101674843576949643467",
  "aud": "_2_KE3Hp8mVWv2TLGwEry--R1YO9zEwQ",
  "exp": 1499402836,
  "iat": 1499366836
}
```
After changes:
```
{
  "email": "german@creativa77.com.ar",
  "email_verified": true,
  "iss": "https://germanmas.auth0.com/",
  "sub": "google-oauth2|101674843576949643467",
  "aud": "_2_KE3Hp8mVWv2TLGwEry--R1YO9zEwQ",
  "exp": 1499403213,
  "iat": 1499367213
}
```

ptal @basicNew